### PR TITLE
Rest api search records

### DIFF
--- a/invenio_alma/ext.py
+++ b/invenio_alma/ext.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2021-2022 Graz University of Technology.
+# Copyright (C) 2021-2023 Graz University of Technology.
 #
 # invenio-alma is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Invenio module to connect InvenioRDM to Alma."""
 
-from .services import AlmaRESTService
+from .resources import AlmaResource, AlmaResourceConfig
+from .services import AlmaRESTService, AlmaSRUService
 
 
 class InvenioAlma:
@@ -21,6 +22,7 @@ class InvenioAlma:
     def init_app(self, app):
         """Flask application initialization."""
         self.init_services(app)
+        self.init_resources(app)
         app.extensions["invenio-alma"] = self
 
     def init_services(self, app):
@@ -29,3 +31,14 @@ class InvenioAlma:
         api_host = app.config.get("ALMA_API_HOST", "")
 
         self.alma_rest_service = AlmaRESTService.build(api_key, api_host)
+
+    def init_resources(self, app):
+        """Initialize resources."""
+        search_key = "local_control_field_009"  # ac_number
+        domain = app.config.get("ALMA_SRU_DOMAIN")
+        institution_code = app.config.get("ALMA_SRU_INSTITUTION_CODE")
+        if domain and institution_code:
+            self.alma_resource = AlmaResource(
+                service=AlmaSRUService.build(search_key, domain, institution_code),
+                config=AlmaResourceConfig,
+            )

--- a/invenio_alma/resources/__init__.py
+++ b/invenio_alma/resources/__init__.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2023 Graz University of Technology.
+#
+# invenio-alma is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Invenio resources to connect InvenioRDM to Alma."""
+
+from .config import AlmaResourceConfig
+from .resources import AlmaResource
+
+__all__ = (
+    "AlmaResourceConfig",
+    "AlmaResource",
+)

--- a/invenio_alma/resources/config.py
+++ b/invenio_alma/resources/config.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+#
+# Copyright (C) 2023 Graz University of Technology.
+#
+# invenio-alma is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Alma Resources configuration."""
+
+import marshmallow as ma
+from flask_resources import ResourceConfig, ResponseHandler
+from invenio_records_marc21.resources.serializers import (
+    Marc21JSONSerializer,
+    Marc21XMLSerializer,
+)
+from invenio_records_marc21.resources.serializers.ui import Marc21UIXMLSerializer
+
+
+class AlmaResourceConfig(ResourceConfig):  # pylint: disable=too-few-public-methods
+    """Marc21 Record resource configuration."""
+
+    blueprint_name = "alma_records"
+    url_prefix = "/alma"
+
+    routes = {
+        "item": "/<any({types}):type>/<record_id>",
+    }
+
+    response_handlers = {
+        "application/json": ResponseHandler(Marc21JSONSerializer()),
+        "application/marcxml": ResponseHandler(Marc21XMLSerializer()),
+        "application/vnd.inveniomarc21.v1+marcxml": ResponseHandler(
+            Marc21UIXMLSerializer()
+        ),
+    }
+
+    record_id_search_key = {
+        "ac_number": "local_control_field_009",
+        "mmsid": "mms_id",
+    }
+
+    # Request parsing
+    request_read_args = {}
+    request_view_args = {"type": ma.fields.Str(), "record_id": ma.fields.Field()}

--- a/invenio_alma/resources/resources.py
+++ b/invenio_alma/resources/resources.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+#
+# Copyright (C) 2023 Graz University of Technology.
+#
+# invenio-alma is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Alma API Resource."""
+
+
+from flask import abort
+from flask_resources import (
+    Resource,
+    from_conf,
+    request_body_parser,
+    request_parser,
+    resource_requestctx,
+    response_handler,
+    route,
+)
+from invenio_records_marc21 import Marc21Metadata
+
+from ..services.errors import AlmaAPIError
+from .config import AlmaResourceConfig
+
+request_view_args = request_parser(from_conf("request_view_args"), location="view_args")
+request_read_args = request_parser(from_conf("request_read_args"), location="args")
+
+request_data = request_body_parser(
+    parsers=from_conf("request_body_parsers"),
+    default_content_type=from_conf("default_content_type"),
+)
+
+
+class AlmaResource(Resource):
+    """Bibliographic record resource."""
+
+    config_name = "ALMA_RESOURCES_CONFIG"
+    default_config = AlmaResourceConfig
+
+    def __init__(self, service, config=default_config):
+        """Initialize the alma resource."""
+        super().__init__(config=config)
+        self.service = service
+
+    def create_url_rules(self):
+        """Create the URL rules for the record resource."""
+        routes = self.config.routes
+        types = ",".join(self.config.record_id_search_key.keys())
+        rules = [
+            route("GET", routes["item"].format(types=types), self.read),
+        ]
+
+        return rules
+
+    @request_read_args
+    @request_view_args
+    @response_handler()
+    def read(self):
+        """Read an item."""
+        record_id = resource_requestctx.view_args["record_id"]
+        type_id = resource_requestctx.view_args["type"]
+
+        self.service.config.search_key = self.config.record_id_search_key[type_id]
+        try:
+            metadata = Marc21Metadata(metadata=self.service.get_record(record_id))
+            item = metadata.json
+        except AlmaAPIError:
+            abort(404)
+        return item, 200

--- a/invenio_alma/services/config.py
+++ b/invenio_alma/services/config.py
@@ -18,7 +18,7 @@ class AlmaRESTConfig:
     api_host: str = ""
 
 
-@dataclass(frozen=True)
+@dataclass
 class AlmaSRUConfig:
     """Alma sru service config."""
 

--- a/invenio_alma/views.py
+++ b/invenio_alma/views.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2023 Graz University of Technology.
+#
+# invenio-alma is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Alma Views module."""
+
+
+def create_record_bp(app):
+    """Create records blueprint."""
+    ext = app.extensions["invenio-alma"]
+    return ext.alma_resource.as_blueprint()

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,10 @@ console_scripts =
     alma = invenio_alma.cli:alma
 invenio_base.apps =
     invenio_alma = invenio_alma:InvenioAlma
+invenio_base.api_apps =
+    invenio_alma = invenio_alma:InvenioAlma
+invenio_base.api_blueprints =
+    invenio_alma_records = invenio_alma.views:create_record_bp
 invenio_celery.tasks =
     invenio_alma = invenio_alma.tasks
 


### PR DESCRIPTION
Add an alma read endpoint to get records from service. The  response can be converted into different types.
The record can be searched with the ac number or mmsid.

**DEMO**
Call the rest api: https://127.0.0.1:5000/api/alma/<record_id>
By setting the "Accept" header property different responses will be created.