### PR TITLE
setup: re-add isort configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -68,6 +68,9 @@ all_files = 1
 [bdist_wheel]
 universal = 1
 
+[tool:isort]
+profile = black
+
 [check-manifest]
 ignore =
     *-requirements.txt


### PR DESCRIPTION
* the isort configuration was removed by the ruff migration, but it is
  not useless it is necessary that isort is working on the save hook (at
  least in emacs)
