### PR TITLE
setup: add python3.12 support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2021-2023 Graz University of Technology.
+# Copyright (C) 2021-2024 Graz University of Technology.
 #
 # invenio-alma is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -21,11 +21,12 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 
 [options]
 include_package_data = True
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.9
 zip_safe = False
 install_requires =
     click>=7.0.0
@@ -37,10 +38,11 @@ install_requires =
 
 [options.extras_require]
 tests =
+    invenio-app>=1.5.0
     invenio-cache>=1.1.0
     invenio-search[opensearch2]>=2.1.0
     pytest-invenio>=1.4.3
-    pytest-black>=0.3.0
+    pytest-black-ng>=0.4.0
     ruff>=0.0.263
     Sphinx>=4.2.0
 


### PR DESCRIPTION
* the invenio-app has to be in the test install requires

* the minimum supported is now python 3.9

* move pytest-black to pytest-black-ng, former unsupported
