### PR TITLE
fix(jobs): custom args

### DIFF
--- a/invenio_alma/jobs.py
+++ b/invenio_alma/jobs.py
@@ -17,6 +17,12 @@ from .tasks import create_alma_records, update_repository_records
 class AlmaPredefinedArgsSchema(PredefinedArgsSchema):
     """Alma predefined args schema."""
 
+    job_arg_schema = String(
+        metadata={"type": "hidden"},
+        dump_default="AlmaPredefinedArgsSchema",
+        load_default="AlmaPredefinedArgsSchema",
+    )
+
     workflow = String(
         metadata={
             "description": "choose workflow to run the task",


### PR DESCRIPTION
* the further implementation only worked because of the "wrap_args"
  pre_load method in RunSchema which has been removed

related to: https://github.com/inveniosoftware/invenio-jobs/issues/100