### PR TITLE
fix: not marked as property

### DIFF
--- a/invenio_alma/services/config.py
+++ b/invenio_alma/services/config.py
@@ -19,6 +19,7 @@ class AlmaRESTConfig:
     api_host: str = ""
     time_out: str = ""
 
+    @property
     def timeout(self) -> int:
         """Get timeout."""
         return int(self.time_out)


### PR DESCRIPTION
* since it was not marked as property, it was wrongly used without
  parenthesis and therefore not an int but a callable is given to
  AlmaREST
